### PR TITLE
Add instructions drawer

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -166,6 +166,16 @@ describe('App', () => {
     expect(getBars(container)).toHaveLength(0);
   });
 
+  it('shows instructions on clicking "how does it work"', async () => {
+    const { getByText, queryByText } = render(<App />);
+
+    const button = getByText(/how does it work/i);
+
+    expect(queryByText(/request your data from facebook/i)).not.toBeInTheDocument();
+    fireEvent.click(button);
+    expect(queryByText(/request your data from facebook/i)).toBeInTheDocument();
+  });
+
   function getBars(container: HTMLElement): SVGRectElement[] {
     return Array.from(container.querySelectorAll('rect')).filter(isNotChartContainerRect);
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { emptyData } from './dataUtils';
 import { TimeUnit, Data } from './models';
 
 import Upload from './Upload';
+import InstructionsButton from './InstructionsButton';
 import TimeUnitRadio from './TimeUnitRadio';
 import Senders from './Senders';
 import EmptyState from './EmptyState';
@@ -27,6 +28,8 @@ const App: FC = () => {
 
       <div style={{ display: 'flex' }}>
         <div>
+          <InstructionsButton />
+
           <Upload
             onComplete={(newData): void => {
               setSelectedSenders(newData.senders);
@@ -52,8 +55,6 @@ const App: FC = () => {
             />
           )}
         </div>
-
-        {/* TODO: Add instructions drawer for how to download data and what to upload */}
 
         {/* TODO: Add keyword filtering */}
 

--- a/src/InstructionsButton/InstructionsButton.tsx
+++ b/src/InstructionsButton/InstructionsButton.tsx
@@ -1,0 +1,94 @@
+import React, { FC, useState } from 'react';
+import { Button, Drawer, Typography } from 'antd';
+import { ButtonProps } from 'antd/lib/button';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+
+const { Paragraph, Text } = Typography;
+
+const InstructionsButton: FC<ButtonProps> = ({ style }) => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  return (
+    <div>
+      <Button type="link" block onClick={(): void => setIsDrawerOpen(true)} style={style}>
+        How does it work
+        <QuestionCircleOutlined />
+      </Button>
+
+      <Drawer
+        title="How does it work"
+        onClose={(): void => setIsDrawerOpen(false)}
+        visible={isDrawerOpen}
+        width={480}
+        footer={
+          <div style={{ textAlign: 'center' }}>
+            Made with{' '}
+            <span role="img" aria-label="love">
+              💙
+            </span>{' '}
+            by{' '}
+            <a href="https://github.com/oliverviljamaa" target="_blank" rel="noopener noreferrer">
+              Oliver Viljamaa
+            </a>
+            .
+          </div>
+        }
+      >
+        <Paragraph>
+          You need to request your data from Facebook to get the message files needed to use this
+          visualization tool. It&apos;s easy and secure, but you may need to wait a bit.
+        </Paragraph>
+
+        <ol>
+          <li>
+            Follow{' '}
+            <a
+              href="https://www.facebook.com/help/212802592074644"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Facebook&apos;s guide on how to request a copy of your data
+            </a>
+            . Select only <Text strong>Messages</Text> from the categories in the download page.
+            Choose <Text strong>Format: JSON</Text> and <Text strong>Media Quality: Low</Text> and
+            click <Text strong>Create File</Text>.
+          </li>
+
+          <li>
+            When the file is ready, Facebook will send you an email titled{' '}
+            <Text strong>Your Facebook information file is ready</Text>. If you have many messages,
+            this may take up to a few days.
+          </li>
+
+          <li>
+            Download the file from the link in the email and extract the zipped file&apos;s
+            contents.
+          </li>
+
+          <li>
+            Come back to this site, click <Text strong>Upload messages</Text> and select all the{' '}
+            <Text strong>messages_*.json</Text> files from any chat folder. You&apos;ll find the
+            chat folders in the <Text strong>inbox/</Text> folder in the folder you just extracted.
+          </li>
+
+          <li>
+            Don&apos;t worry, your messages are never uploaded anywhere — the tool is built with
+            privacy in mind and works locally on your computer. To verify this, try loading the
+            page, turning off your internet connection, and uploading some messages: the tool will
+            still work.
+          </li>
+
+          <li>
+            Enjoy and{' '}
+            <a href="https://forms.gle/Dqn4NC6tRrH1D5qA7" target="_blank" rel="noopener noreferrer">
+              leave feedback
+            </a>
+            !
+          </li>
+        </ol>
+      </Drawer>
+    </div>
+  );
+};
+
+export default InstructionsButton;

--- a/src/InstructionsButton/index.ts
+++ b/src/InstructionsButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InstructionsButton';

--- a/src/Upload/Upload.tsx
+++ b/src/Upload/Upload.tsx
@@ -10,7 +10,7 @@ import './Upload.css';
 
 type UploadProps = {
   onComplete: (data: Data) => void;
-  style: CSSProperties;
+  style?: CSSProperties;
 };
 
 // TODO: Support uploading a directory, from where all messages_*.json files would be used


### PR DESCRIPTION
Adds a drawer with instructions on how to request the data from Facebook and how to upload the messages. It also mentions the fact that the data is safe and has a small author's note.

**Before:**
![oliverviljamaa github io_messenger-stats_ (3)](https://user-images.githubusercontent.com/5443561/78455270-fa586580-76a5-11ea-809f-f6d778016343.png)

**After:**
![localhost_3000_ (1)](https://user-images.githubusercontent.com/5443561/78455276-017f7380-76a6-11ea-8ca4-45130f0d30d6.png)
