### PR TITLE
Show meaningful warning instead of non-functional app on smaller viewports

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -44,6 +44,7 @@ describe('App', () => {
 
   it('shows empty state and on upload, replaces it with correct columns and updates on time unit change', async () => {
     mockBoundingRectSoChartWouldBeRendered();
+    mockMatchMediaForRowsAndColsToWork();
 
     const { getByText, container } = render(<App />);
 
@@ -120,6 +121,7 @@ describe('App', () => {
 
   it('shows no senders, on upload shows senders with same colors as bars, and allows filtering', async () => {
     mockBoundingRectSoChartWouldBeRendered();
+    mockMatchMediaForRowsAndColsToWork();
 
     const { getByText, queryAllByRole, container } = render(<App />);
 
@@ -229,6 +231,22 @@ describe('App', () => {
       bottom: 0,
       left: 0,
       toJSON: jest.fn(),
+    });
+  }
+
+  function mockMatchMediaForRowsAndColsToWork(): void {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
     });
   }
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from 'react';
-import { Typography } from 'antd';
+import { Typography, Row, Col, Alert } from 'antd';
 
 import { emptyData } from './dataUtils';
 import { TimeUnit, Data } from './models';
@@ -26,50 +26,61 @@ const App: FC = () => {
     <main style={{ padding: 32 }}>
       <Title>Messenger stats</Title>
 
-      <div style={{ display: 'flex' }}>
-        <div>
-          <InstructionsButton />
-
-          <Upload
-            onComplete={(newData): void => {
-              setSelectedSenders(newData.senders);
-              setData(newData);
-            }}
-            style={{ marginBottom: 24 }}
+      <Row>
+        <Col xs={24} lg={0}>
+          <Alert
+            message="To use the visualization tool, please return to this page on a device with a bigger screen, such as your laptop or desktop computer."
+            type="warning"
           />
+        </Col>
 
-          <TimeUnitRadio
-            selected={selectedTimeUnit}
-            onSelect={setSelectedTimeUnit}
-            disabled={data === emptyData}
-            disabledUnits={getTimeUnitsToDisable(data)}
-            style={{ marginBottom: 24 }}
-          />
+        <Col xs={0} lg={24}>
+          <div style={{ display: 'flex' }}>
+            <div>
+              <InstructionsButton />
 
-          {senders.length > 0 && (
-            <Senders
-              senders={senders}
-              selected={selectedSenders}
-              onChange={setSelectedSenders}
-              colors={COLORS}
-            />
-          )}
-        </div>
+              <Upload
+                onComplete={(newData): void => {
+                  setSelectedSenders(newData.senders);
+                  setData(newData);
+                }}
+                style={{ marginBottom: 24 }}
+              />
 
-        {/* TODO: Add keyword filtering */}
+              <TimeUnitRadio
+                selected={selectedTimeUnit}
+                onSelect={setSelectedTimeUnit}
+                disabled={data === emptyData}
+                disabledUnits={getTimeUnitsToDisable(data)}
+                style={{ marginBottom: 24 }}
+              />
 
-        {/* TODO: Add chat title */}
+              {senders.length > 0 && (
+                <Senders
+                  senders={senders}
+                  selected={selectedSenders}
+                  onChange={setSelectedSenders}
+                  colors={COLORS}
+                />
+              )}
+            </div>
 
-        {/* TODO: Add loading state */}
+            {/* TODO: Add keyword filtering */}
 
-        <div style={{ flex: 1 }}>
-          {data === emptyData ? (
-            <EmptyState />
-          ) : (
-            <Chart senders={selectedSenders} data={dataForTimeUnit} colors={COLORS} />
-          )}
-        </div>
-      </div>
+            {/* TODO: Add chat title */}
+
+            {/* TODO: Add loading state */}
+
+            <div style={{ flex: 1 }}>
+              {data === emptyData ? (
+                <EmptyState />
+              ) : (
+                <Chart senders={selectedSenders} data={dataForTimeUnit} colors={COLORS} />
+              )}
+            </div>
+          </div>
+        </Col>
+      </Row>
     </main>
   );
 };

--- a/src/InstructionsButton/InstructionsButton.tsx
+++ b/src/InstructionsButton/InstructionsButton.tsx
@@ -19,7 +19,7 @@ const InstructionsButton: FC<ButtonProps> = ({ style }) => {
         title="How does it work"
         onClose={(): void => setIsDrawerOpen(false)}
         visible={isDrawerOpen}
-        width={480}
+        width={Math.min(window.innerWidth, 480)}
         footer={
           <div style={{ textAlign: 'center' }}>
             Made with{' '}


### PR DESCRIPTION
Downloading the message files to a mobile device and analysing the data on a small screen would not be a good experience, so on smaller screens, a warning message is shown instead of the app.

Although this means the instructions drawer will never be shown on mobile, its width has been made responsive due to the low effort it required and potential future use cases.

**Before:**
<img src="https://user-images.githubusercontent.com/5443561/78498555-a310ce80-7753-11ea-82ce-a6baf6779e8a.png" width="240" />

**After:**
<img src="https://user-images.githubusercontent.com/5443561/78498557-a6a45580-7753-11ea-8a32-efeb4a3aeb53.png" width="240" />