### PR TITLE
Time unit selected on initialisation

### DIFF
--- a/src/TimeUnitRadio/TimeUnitRadio.tsx
+++ b/src/TimeUnitRadio/TimeUnitRadio.tsx
@@ -11,7 +11,6 @@ type TimeUnitRadioProps = {
   style: CSSProperties;
 };
 
-// TODO: Fix no time unit being selected on initialisation
 const TimeUnitRadio: FC<TimeUnitRadioProps> = ({
   selected,
   onSelect,
@@ -19,7 +18,7 @@ const TimeUnitRadio: FC<TimeUnitRadioProps> = ({
   disabledUnits,
   style,
 }) => (
-  <Radio.Group disabled={disabled} style={style}>
+  <Radio.Group disabled={disabled} style={style} defaultValue={selected}>
     {Object.values(TimeUnit).map(unit => (
       <Radio.Button
         value={unit}


### PR DESCRIPTION
Currently, no time unit is selected on initialisation, and it's not updated even after uploading the messages. This is due to Ant's radio not changing state based on the first `selected` value.

**Before and after**
<img src="https://user-images.githubusercontent.com/5443561/91138888-db3f8c00-e6b7-11ea-890c-b848954a9c3c.png" /> <img src="https://user-images.githubusercontent.com/5443561/91138864-da0e5f00-e6b7-11ea-8752-bb2152956a7f.png" />